### PR TITLE
Camera disabled on play scene

### DIFF
--- a/principal/cenas/autoloads/Camera.tscn
+++ b/principal/cenas/autoloads/Camera.tscn
@@ -49,6 +49,7 @@ _data = {
 
 [node name="Camera" type="Camera2D"]
 position = Vector2(960, 540)
+enabled = false
 script = ExtResource("1")
 
 [node name="AnimationPlayer" type="AnimationPlayer" parent="."]

--- a/principal/cenas/scripts/Opening.gd
+++ b/principal/cenas/scripts/Opening.gd
@@ -6,6 +6,8 @@ extends "res://principal/cenas/scripts/ToTitle.gd"
 
 func _ready():
 	animation_player.play("opening")
+	
+	GlobalCamera.enabled = true
 
 
 func _input(event):


### PR DESCRIPTION
Enables people to play minigame scenes without having to manually disable the GlobalCamera, as it will now be disabled by default and be enabled in the opening scene's _ready() call