### PR TITLE
fix win condition in witnesss

### DIFF
--- a/microjogos/2023S1/projeto-pochete/cenas/scripts/main.gd
+++ b/microjogos/2023S1/projeto-pochete/cenas/scripts/main.gd
@@ -112,7 +112,9 @@ func _on_head_area_exited(area):
 		for tail in head.tail_nodes:
 			if area.overlaps_area(tail):
 				in_tail = true
-				gotten_apples.append(area)
+				if area not in gotten_apples:
+					gotten_apples.append(area)
+				break
 		if not in_tail:
 			var i = gotten_apples.find(area)
 			if i > -1:


### PR DESCRIPTION
Corrige bug na condição de vitória do Witnesss

Podia acontecer de o jogo contar que você comeu a mesma maçã mais de uma vez, e como a condição de vitória é comer exatamente 2 maçãs e a maçã final, a condição falha e o jogo considera que você perdeu. A correção foi impedir de contabilizar a mesma maçã mais de uma vez