### PR TITLE
fix apple detection and add QOL

### DIFF
--- a/microjogos/2023S1/projeto-pochete/cenas/main.tscn
+++ b/microjogos/2023S1/projeto-pochete/cenas/main.tscn
@@ -294,7 +294,7 @@ collide_with_bodies = false
 
 [node name="Music" type="AudioStreamPlayer" parent="."]
 stream = ExtResource("5_6liii")
-volume_db = 10.0
+volume_db = 24.0
 autoplay = true
 
 [node name="AppleBite" type="AudioStreamPlayer" parent="."]

--- a/microjogos/2023S1/projeto-pochete/cenas/scripts/main.gd
+++ b/microjogos/2023S1/projeto-pochete/cenas/scripts/main.gd
@@ -12,7 +12,6 @@ const WIDTH = 1920
 const HEIGHT = 1080
 
 var chosen_apples = []
-var gotten_apples = []
 var won = false
 @onready var snake = get_node("Snake")
 @onready var head = get_node("Snake/Head")
@@ -60,7 +59,6 @@ func _process(delta):
 				head.visible = false
 				for j in range(len(head.tail_nodes)):
 					head.tail_nodes[j].visible = false
-				$Music.stop()
 
 
 # --------------------------------------------------------------------------------------------------
@@ -106,30 +104,26 @@ func register_lose():
 	emit_signal("lose")
 
 
-func _on_head_area_exited(area):
-	if area in chosen_apples:
-		var in_tail = false
-		for tail in head.tail_nodes:
-			if area.overlaps_area(tail):
-				in_tail = true
-				if area not in gotten_apples:
-					gotten_apples.append(area)
-				break
-		if not in_tail:
-			var i = gotten_apples.find(area)
-			if i > -1:
-				gotten_apples.remove_at(i)
-
-
 func _on_head_area_entered(area):
-	if area in chosen_apples + [final_apple] and area not in gotten_apples:
+	if area in chosen_apples + [final_apple]:
 		$AppleBite.play()
-	if area == final_apple and len(gotten_apples) == 2:
-		register_win()
-		won = true
-		won_i = len(head.tail_nodes)
-		#head.tail_nodes[-1].position = head.position
-		for j in range(won_i - 1):
-			head.tail_nodes[j].position = head.tail_nodes[j+1].position
-		for apple in chosen_apples + [final_apple]:
-			apple.visible = false
+	if area == final_apple:
+		var apple_count = [false, false]
+		var win = false
+		for tail in head.tail_nodes:
+			for i in [0, 1]:
+				if chosen_apples[i].overlaps_area(tail):
+					apple_count[i] = true
+					break
+			if apple_count == [true, true]:
+				win = true
+				break
+		if win:
+			register_win()
+			won = true
+			won_i = len(head.tail_nodes)
+			#head.tail_nodes[-1].position = head.position
+			for j in range(won_i - 1):
+				head.tail_nodes[j].position = head.tail_nodes[j+1].position
+			for apple in chosen_apples + [final_apple]:
+				apple.visible = false


### PR DESCRIPTION
Às vezes acontecia do Witnesss não acionar a condição de vitória, mesmo tendo comido todas as frutas. Para corrigir isso, a lógica de vitória foi alterada para ser calculada somente ao final, ao invés de ser calculada progressivamente ao longo do minigame. Minha teoria é de que havia algum compartilhamento de memórias entre sessões consecutivas do jogo, o que era um problema pois a condição de vitória dependia de variáveis globais da main :skull: . Como a condição de vitória agora depende de variáveis locais, creio que isso não é mais um problema.

Para reproduzir o problema, criei um novo pack de minigames somente com o Witnesss e joguei no arcade. A configuração do Minigames.gd ficou +- assim:

```GDScript
const minigame_packs = {
	"demo": ["res://microjogos/2023S1/projeto-pochete/cenas/main.tscn"],
        "...": ["..."],
```

Esse PR também traz algumas mudanças de qualidade de vida, incluindo:

- A cobra anda até a intersecção com cada interação, facilitando o minigame no controle
- A cobra começa uma posição acima. Acontecia dos jogadores ficarem perdidos antes pois o timer ficava em cima da cobra, espero que isso resolva este problema.
- Aumentei o ganho de volume da música. Ela é uma coleção de sons ambientes, então o som já era mais baixo que a música do Arcade, isso deve tornar ela um tico mais audível. (Em meus sonhos, conseguimos a licença para usar [alguma música do Plantasia do Mort Garson](https://youtube.com/playlist?list=PLPjyNpPpyEt1XgNHieFI48ihvmQl5K8V2), mas aceito sugestões de músicas parecidas)