### PR TITLE
Add '*.import' to '.gitignore'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 /.godot
 /.import
 /principal/saves/save.tres
+*.import


### PR DESCRIPTION
Simple addition, but necessary.

As the project gets cloned, in the first time it gets opened by Godot all of the assets get imported, and the engine makes `.import` files for every one of them. In the current version of the `.gitignore` file, it only ignores the `.import` folder, but doesn't account for the file extesion, getting unnecessary changes in the way.