### PR TITLE
Add difficulty counter

### DIFF
--- a/principal/cenas/scripts/Global.gd
+++ b/principal/cenas/scripts/Global.gd
@@ -20,6 +20,7 @@ var queued_method
 var queued_parameters
 
 var language
+var difficulty: int = 0
 
 func _ready():
 	var root = get_tree().get_root()

--- a/principal/cenas/scripts/Jogo.gd
+++ b/principal/cenas/scripts/Jogo.gd
@@ -28,7 +28,10 @@ var icon_dict = {}
 var microgame_dict = {}
 
 var total_lives = 3
-var score = 0
+var score = 0 :
+	set(value):
+		score = value
+		Global.difficulty = int((value - (value % 5)) / 5)
 
 var difficulty_level = 0
 var difficulty_slot = 0


### PR DESCRIPTION
Every 5 games won, the difficulty increases, and the variable can be accessed via `Global.difficulty`. It's not obligatory that minigames use it, but this will help balance minigames that were once too difficult or too easy.